### PR TITLE
Move from hdb to mdb openldap 2.5

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,29 @@
+name: Tests
+
+on:
+  push:
+   branches: [move-from-hdb-to-mdb-openldap-2.5]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install deps
+        run: |
+          sudo apt-get install -yqq slapd ldap-utils
+          apt-cache show slapd
+          pip install .[dev]
+
+      - name: Allow slapd to read config from /tmp
+        run: |
+          echo "/tmp/** rwk," | sudo tee -a /etc/apparmor.d/local/usr.sbin.slapd
+          sudo systemctl reload apparmor
+
+      - run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ build/
 dist/
 htmlcov/
 MANIFEST
+.venv/

--- a/tox.ini
+++ b/tox.ini
@@ -5,10 +5,10 @@ envlist =
 
 [testenv]
 extras = dev
-whitelist_externals = make
+allowlist_externals = make
 commands = make test
 
 [testenv:lint]
 extras = dev
-whitelist_externals = make
+allowlist_externals = make
 commands = make lint

--- a/volatildap/server.py
+++ b/volatildap/server.py
@@ -144,8 +144,8 @@ class LdapServer(core.BaseServer):
             yield quote('TLSCertificateFile %s', self._tls_certificate_path)
             yield quote('TLSCertificateKeyFile %s', self._tls_key_path)
 
-        yield quote('moduleload back_hdb')
-        yield quote('database hdb')
+        yield quote('moduleload back_mdb')
+        yield quote('database mdb')
         yield quote('directory %s', self._datadir)
         yield quote('suffix %s', self.suffix)
         yield quote('rootdn %s', self.rootdn)


### PR DESCRIPTION
This stops using the HDB backend, which was removed in OpenLDAP v2.5

Also add a GitHub actions test workflow 